### PR TITLE
add 'ranking does not exist' message / average_time 소수점 2자리까지 표시

### DIFF
--- a/record/views.py
+++ b/record/views.py
@@ -120,6 +120,9 @@ class UserRankView(View):
             )
         )
 
+        if len(ranking_list) == 0:
+            return JsonResponse({"message" : "RANKING_DOES_NOT_EXIST"}, status = 400)
+
         ordered_table = get_ranking(ranking_list, order_by, int(limit))
 
         user_ranking = [
@@ -130,7 +133,7 @@ class UserRankView(View):
                 "store_id"         : user.store_id,
                 "store_name"       : user.store.name,
                 "count"            : user.total_count,
-                "average_time"     : round(user.average_time),
+                "average_time"     : round(user.average_time, 2),
                 "shortest_time"    : user.shortest_time,
                 "quality"          : round(user.average_quality),
                 "sauce"            : round(user.average_sauce),
@@ -173,6 +176,9 @@ class StoreRankView(View):
             )
         )
 
+        if len(ranking_list) == 0:
+            return JsonResponse({"message" : "RANKING_DOES_NOT_EXIST"}, status = 400)
+
         ordered_table = get_ranking(ranking_list, order_by, int(limit))
 
         store_ranking = [
@@ -180,7 +186,7 @@ class StoreRankView(View):
                 "id"               : store.id,
                 "name"             : store.name,
                 "count"            : store.total_count,
-                "average_time"     : round(store.average_time),
+                "average_time"     : round(store.average_time, 2),
                 "shortest_time"    : store.shortest_time,
                 "quality"          : round(store.average_quality),
                 "sauce"            : round(store.average_sauce),


### PR DESCRIPTION
1) Ranking 관련하여 return 되는 data가 없을 때, 500에러가 뜨는 것을 확인.
빈 데이터일 경우에 RANKING_DOES_NOT_EXIST를 front에 response 해주도록 추가.

2) Front의 요청으로 평균시간(average_time)을 소수점 셋째자리에서 반올림하여 2자리까지 표시하도록 변경.
소수점까지 표기하지 않으면 같은 점수를 가진 user가 많이 발생하는 것을 확인.