### PR TITLE
user list view에서 grade, is_approved 기준으로 정렬하도록 변경

### DIFF
--- a/user/views.py
+++ b/user/views.py
@@ -185,6 +185,7 @@ class UserGetView(View):
             .filter(**filter_condition)
             .filter(~Q(grade_id = 1))
             .select_related('grade', 'store')
+            .order_by('-grade__name', 'is_approved')
             .values(
                 "id",
                 "name",
@@ -251,6 +252,7 @@ class UserInfoView(View):
                 "id",
                 "name",
                 "email",
+                "grade__name",
                 "store__name",
                 "image"
             )


### PR DESCRIPTION
1) User들 list에서 등급(manager, crew)과 가입승인 여부를 기준으로 정렬하도록 변경
2) front의 요청으로 user info에 grade name도 return 하도록 변경