### PR TITLE
UserQuestHistory 생성, user에 score가 없으면 user info만 return 하도록 변경

### DIFF
--- a/record/views.py
+++ b/record/views.py
@@ -261,7 +261,11 @@ class UserScoreView(View):
             return JsonResponse({"user_info" : user_info}, status = 200)
 
         except IndexError:
-            return JsonResponse({"message" : "SCORE_DOES_NOT_EXIST"}, status = 400)
+            return JsonResponse({"user_info" : list(User
+                                                    .objects
+                                                    .filter(id = user_id)
+                                                    .values('id', 'image','store__name'))},
+                                status = 200)
 
 class StoreScoreView(View):
     def get(self, request, store_id):

--- a/user/views.py
+++ b/user/views.py
@@ -9,6 +9,7 @@ from PIL import Image
 from io  import BytesIO
 
 from .models      import User, Grade, Verification
+from quest.models import UserQuestHistory
 from store.models import Store
 from my_settings  import SECRET, ALGORITHM, EMAIL, S3
 from .texts       import message
@@ -274,6 +275,15 @@ class ApprovalView(View):
             return JsonResponse({"message" : "Forbidden"}, status = 403)
 
         User.objects.filter(id = user_id).update(is_approved = True)
+
+        for num in range(1, 6):
+            UserQuestHistory(
+                is_achieved = False,
+                is_claimed  = False,
+                is_rewarded = False,
+                quest_id    = num,
+                user_id     = user_id
+            ).save()
 
         return HttpResponse(status = 200)
 


### PR DESCRIPTION
1) crew가 가입하고 manager가 승인을 하면, UserQuestHistory에 해당 crew가 quest 정보를 가지도록 변경
2) 특정 user에게 score 정보가 없으면 user info(id, name, store name)만 return 하도록 변경 (front 요청)